### PR TITLE
fix for es<5 not having Array.isArray()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -22,7 +22,8 @@
 // NOTE: These type checking functions intentionally don't use `instanceof`
 // because it is fragile and can be easily faked with `Object.create()`.
 function isArray(ar) {
-  return Array.isArray(ar);
+  if (Array.isArray) return Array.isArray(ar);
+  return objectToString(ar) === '[object Array]';
 }
 exports.isArray = isArray;
 


### PR DESCRIPTION
I'm trying to get readable-stream to work in old browsers and this module is one of its downstream dependencies. This patch just defers to the toString '[object Array]' trick for isArray if Array.isArray isn't present.