### PR TITLE
Removing redundant checks

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -26,7 +26,7 @@ function isArray(arg) {
   if (Array.isArray) {
     return Array.isArray(arg);
   }
-  return objectToString(ar) === '[object Array]';
+  return objectToString(arg) === '[object Array]';
 }
 exports.isArray = isArray;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,10 +21,8 @@
 
 // NOTE: These type checking functions intentionally don't use `instanceof`
 // because it is fragile and can be easily faked with `Object.create()`.
-function isArray(ar) {
-  return Array.isArray(ar);
-}
-exports.isArray = isArray;
+
+exports.isArray = Array.isArray;
 
 function isBoolean(arg) {
   return typeof arg === 'boolean';
@@ -62,7 +60,7 @@ function isUndefined(arg) {
 exports.isUndefined = isUndefined;
 
 function isRegExp(re) {
-  return isObject(re) && objectToString(re) === '[object RegExp]';
+  return objectToString(re) === '[object RegExp]';
 }
 exports.isRegExp = isRegExp;
 
@@ -72,13 +70,12 @@ function isObject(arg) {
 exports.isObject = isObject;
 
 function isDate(d) {
-  return isObject(d) && objectToString(d) === '[object Date]';
+  return objectToString(d) === '[object Date]';
 }
 exports.isDate = isDate;
 
 function isError(e) {
-  return isObject(e) &&
-      (objectToString(e) === '[object Error]' || e instanceof Error);
+  return (objectToString(e) === '[object Error]' || e instanceof Error);
 }
 exports.isError = isError;
 
@@ -97,10 +94,7 @@ function isPrimitive(arg) {
 }
 exports.isPrimitive = isPrimitive;
 
-function isBuffer(arg) {
-  return Buffer.isBuffer(arg);
-}
-exports.isBuffer = isBuffer;
+exports.isBuffer = Buffer.isBuffer;
 
 function objectToString(o) {
   return Object.prototype.toString.call(o);

--- a/lib/util.js
+++ b/lib/util.js
@@ -22,7 +22,13 @@
 // NOTE: These type checking functions intentionally don't use `instanceof`
 // because it is fragile and can be easily faked with `Object.create()`.
 
-exports.isArray = Array.isArray;
+function isArray(arg) {
+  if (Array.isArray) {
+    return Array.isArray(arg);
+  }
+  return objectToString(ar) === '[object Array]';
+}
+exports.isArray = isArray;
 
 function isBoolean(arg) {
   return typeof arg === 'boolean';


### PR DESCRIPTION
1. When we are comparing the `objectToString` values, `isObject` check is not
   necessary. So removing those checks. Refer https://github.com/nodejs/io.js/pull/2179

2. `Buffer.isArray` need not be run in another function, as it is a static function.

3. Including compatible checks for versions older then ES5, for Arrays. Refer https://github.com/isaacs/core-util-is/pull/3