### PR TITLE
Do not rely on a global Buffer

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -100,7 +100,7 @@ function isPrimitive(arg) {
 }
 exports.isPrimitive = isPrimitive;
 
-exports.isBuffer = Buffer.isBuffer;
+exports.isBuffer = require('buffer').Buffer.isBuffer;
 
 function objectToString(o) {
   return Object.prototype.toString.call(o);


### PR DESCRIPTION
Improve browser handling by not relying on a global Buffer
